### PR TITLE
handling video files

### DIFF
--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -113,6 +113,7 @@ async function readJpegMeta(filepath) {
   log.time(`jpeg ${filepath}`);
 
   const data = await exec('readMetadata', filepath, [
+    'Duration', // used to detect video files
     'Orientation',
     'JpgFromRawLength',
     'JpgFromRawStart',
@@ -132,6 +133,7 @@ async function readJpegMeta(filepath) {
   }
 
   const {
+    Duration,
     Orientation,
     JpgFromRawLength,
     JpgFromRawStart,
@@ -142,6 +144,11 @@ async function readJpegMeta(filepath) {
     Rating
   } = data.data[0];
 
+  if (Duration !== undefined) {
+    return {
+      error: 'video files are not supported'
+    };
+  }
 
   // DNG (any)     - will have Jpeg props for full view and Preview props for thumbs
   // NEF (nikon)   - will have Jpeg props for full view and Preview props for thumbs


### PR DESCRIPTION
#50 

Video files have metadata that can be extracted, but they are not supported in the image viewer (they generally have no embedded image... and certainly there is no video playback in the viewer), so those will be detected and ignored.